### PR TITLE
Added -lm flag to link math library

### DIFF
--- a/C/Makefile
+++ b/C/Makefile
@@ -16,7 +16,7 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 CC = clang
-CC_FLAGS = -Wfatal-errors -Wall -Wextra -Wpedantic -Wconversion -Wshadow
+CC_FLAGS = -Wfatal-errors -Wall -Wextra -Wpedantic -Wconversion -Wshadow -lm
 
 # Final binary
 BIN = cmain


### PR DESCRIPTION
## Description
This PR adds the `-lm` flag to link math libraries in the C implementation of the Neural Network.

## Error Details
Without the `-lm` flag , the following error occurs.

```sh
usr/bin/ld: build/neural.o: in function `sigmoid':
neural.c:(.text+0x3aa): undefined reference to `exp` 
clang: fatal error: linker command failed with exit code 1 (use -v to see invocation)
```

## Changes Made
Adds `-lm` flag to the Makefile located in NeuralNetworkInAllLanges/C directory.

   
